### PR TITLE
Add setTimeout() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ $nmap
     ->scan([ 'williamdurand.fr' ]);
 ```
 
+You can define the process timeout (default to 60 seconds) with `setTimeout()`:
+
+``` php
+$nmap
+    ->setTimeout(120)
+    ->scan([ 'williamdurand.fr' ]);
+```
+
 Installation
 ------------
 

--- a/src/Nmap/Nmap.php
+++ b/src/Nmap/Nmap.php
@@ -37,6 +37,8 @@ class Nmap
 
     private $executable;
 
+    private $timeout = 60;
+
     /**
      * @return Nmap
      */
@@ -49,6 +51,7 @@ class Nmap
      * @param ProcessExecutor $executor
      * @param string          $outputFile
      * @param string          $executable
+     * @param int             $timeout
      *
      * @throws \InvalidArgumentException
      */
@@ -111,7 +114,7 @@ class Nmap
             $targets
         );
 
-        $this->executor->execute($command);
+        $this->executor->execute($command, $this->timeout);
 
         if (!file_exists($this->outputFile)) {
             throw new \RuntimeException(sprintf('Output file not found ("%s")', $this->outputFile));
@@ -188,6 +191,18 @@ class Nmap
     public function treatHostsAsOnline($disable = true)
     {
         $this->treatHostsAsOnline = $disable;
+
+        return $this;
+    }
+
+    /**
+     * @param $timeout
+     *
+     * @return Nmap
+     */
+    public function setTimeout($timeout)
+    {
+        $this->timeout = $timeout;
 
         return $this;
     }

--- a/src/Nmap/Util/ProcessExecutor.php
+++ b/src/Nmap/Util/ProcessExecutor.php
@@ -19,12 +19,13 @@ class ProcessExecutor
 {
     /**
      * @param string $command The command to execute.
+     * @param int    $timeout The process timeout.
      *
      * @return integer
      */
-    public function execute($command)
+    public function execute($command, $timeout = 60)
     {
-        $process = new Process($command);
+        $process = new Process($command, null, null, null, $timeout);
         $process->run();
 
         if (!$process->isSuccessful()) {

--- a/tests/Nmap/Tests/NmapTest.php
+++ b/tests/Nmap/Tests/NmapTest.php
@@ -222,6 +222,37 @@ class NmapTest extends TestCase
         $hosts = $nmap->treatHostsAsOnline()->scan(array('williamdurand.fr'));
     }
 
+    public function testScanWithDefaultTimeout()
+    {
+        $outputFile = __DIR__ . '/Fixtures/test_scan.xml';
+
+        $executor = $this->getProcessExecutorMock();
+        $executor
+            ->expects($this->at(1))
+            ->method('execute')
+            ->with($this->anything(), $this->equalTo(60))
+            ->will($this->returnValue(0));
+
+        $nmap = new Nmap($executor, $outputFile);
+        $nmap->scan(array('williamdurand.fr'));
+    }
+
+    public function testScanWithUserTimeout()
+    {
+        $outputFile = __DIR__ . '/Fixtures/test_scan.xml';
+        $timeout = 123;
+
+        $executor = $this->getProcessExecutorMock();
+        $executor
+            ->expects($this->at(1))
+            ->method('execute')
+            ->with($this->anything(), $this->equalTo($timeout))
+            ->will($this->returnValue(0));
+
+        $nmap = new Nmap($executor, $outputFile);
+        $nmap->setTimeout($timeout)->scan(array('williamdurand.fr'));
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
This PR adds a `Nmap::setTimeout()` method which allow to override the default 60s timeout.

- [x] Doc
- [x] Tests