### PR TITLE
do not used a fixed filename if none is specified 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6

--- a/src/Nmap/Nmap.php
+++ b/src/Nmap/Nmap.php
@@ -58,7 +58,7 @@ class Nmap
     public function __construct(ProcessExecutor $executor = null, $outputFile = null, $executable = 'nmap')
     {
         $this->executor   = $executor ?: new ProcessExecutor();
-        $this->outputFile = $outputFile ?: sys_get_temp_dir() . '/output.xml';
+        $this->outputFile = $outputFile ?: tempnam(sys_get_temp_dir(), 'nmap-scan-output.xml');
         $this->executable = $executable;
 
         // If executor returns anything else than 0 (success exit code), throw an exeption since $executable is not executable.


### PR DESCRIPTION
(stops symlink attacks etc)